### PR TITLE
[Refactor] use unified config save helper

### DIFF
--- a/config_helpers.py
+++ b/config_helpers.py
@@ -1,18 +1,21 @@
 import json
-from typing import Dict, Any, Optional, Tuple
+from typing import Dict, Any
 from dataclasses import dataclass
 from enum import Enum
 import logging
 from config import CONFIG_PATH  # Import CONFIG_PATH from config.py
+import helpers
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+
 class NotificationType(Enum):
     BEAR = "bear"
     ARENA = "arena"
     EVENT = "event"
+
 
 @dataclass
 class BearPingSettings:
@@ -20,10 +23,12 @@ class BearPingSettings:
     pre_attack_enabled: bool = True
     pre_attack_offset: int = 10
 
+
 @dataclass
 class ArenaPingSettings:
     ping_enabled: bool = True
     ping_offset: int = 10
+
 
 @dataclass
 class EventPingSettings:
@@ -32,14 +37,17 @@ class EventPingSettings:
     final_call_enabled: bool = True
     final_call_offset: int = 10
 
+
 class ConfigValidationError(Exception):
     """Raised when config validation fails"""
+
     pass
+
 
 def _load_config() -> Dict[str, Any]:
     """Load the bot config file"""
     try:
-        with open(CONFIG_PATH, 'r') as f:
+        with open(CONFIG_PATH, "r") as f:
             return json.load(f)
     except FileNotFoundError:
         logger.error(f"Config file not found at {CONFIG_PATH}")
@@ -48,22 +56,28 @@ def _load_config() -> Dict[str, Any]:
         logger.error(f"Invalid JSON in config file at {CONFIG_PATH}")
         raise
 
+
 def _save_config(config: Dict[str, Any]) -> None:
     """Save the bot config file"""
     try:
-        with open(CONFIG_PATH, 'w') as f:
-            json.dump(config, f, indent=2)
+        helpers.save_config(config)
         logger.info(f"Saved config to {CONFIG_PATH}")
     except Exception as e:
         logger.error(f"Failed to save config to {CONFIG_PATH}: {e}")
         raise
 
+
 def _validate_offset(offset: int, min_val: int = 1, max_val: int = 60) -> None:
     """Validate that an offset is within allowed range"""
     if not min_val <= offset <= max_val:
-        raise ConfigValidationError(f"Offset must be between {min_val} and {max_val} minutes")
+        raise ConfigValidationError(
+            f"Offset must be between {min_val} and {max_val} minutes"
+        )
 
-def _validate_chronological_order(settings: Dict[str, Any], notification_type: NotificationType) -> None:
+
+def _validate_chronological_order(
+    settings: Dict[str, Any], notification_type: NotificationType
+) -> None:
     """Validate that notification phases maintain chronological order"""
     if notification_type == NotificationType.BEAR:
         if settings.get("pre_attack_enabled", True):
@@ -71,141 +85,157 @@ def _validate_chronological_order(settings: Dict[str, Any], notification_type: N
     elif notification_type == NotificationType.EVENT:
         reminder_offset = settings.get("reminder_offset", 60)
         final_call_offset = settings.get("final_call_offset", 10)
-        if settings.get("reminder_enabled", True) and settings.get("final_call_enabled", True):
+        if settings.get("reminder_enabled", True) and settings.get(
+            "final_call_enabled", True
+        ):
             if reminder_offset <= final_call_offset:
-                raise ConfigValidationError("Reminder offset must be greater than final call offset")
+                raise ConfigValidationError(
+                    "Reminder offset must be greater than final call offset"
+                )
             if reminder_offset - final_call_offset < 5:
-                raise ConfigValidationError("Minimum gap between notifications must be 5 minutes")
+                raise ConfigValidationError(
+                    "Minimum gap between notifications must be 5 minutes"
+                )
 
-def _ensure_notification_settings(config: Dict[str, Any], guild_id: str, notification_type: NotificationType) -> None:
+
+def _ensure_notification_settings(
+    config: Dict[str, Any], guild_id: str, notification_type: NotificationType
+) -> None:
     """Ensure notification settings exist in config for a guild"""
     if guild_id not in config:
         config[guild_id] = {}
-    
+
     guild_config = config[guild_id]
-    
+
     if notification_type.value not in guild_config:
         guild_config[notification_type.value] = {}
-    
+
     if "ping_settings" not in guild_config[notification_type.value]:
         if notification_type == NotificationType.BEAR:
             guild_config[notification_type.value]["ping_settings"] = {
                 "incoming_enabled": True,
                 "pre_attack_enabled": True,
-                "pre_attack_offset": 10
+                "pre_attack_offset": 10,
             }
         elif notification_type == NotificationType.ARENA:
             guild_config[notification_type.value]["ping_settings"] = {
                 "ping_enabled": True,
-                "ping_offset": 10
+                "ping_offset": 10,
             }
         elif notification_type == NotificationType.EVENT:
             guild_config[notification_type.value]["ping_settings"] = {
                 "reminder_enabled": True,
                 "reminder_offset": 60,
                 "final_call_enabled": True,
-                "final_call_offset": 10
+                "final_call_offset": 10,
             }
+
 
 # Bear notification helpers
 def get_bear_ping_settings(guild_id: str) -> BearPingSettings:
     """Get bear notification settings for a guild"""
     config = _load_config()
     _ensure_notification_settings(config, guild_id, NotificationType.BEAR)
-    
+
     settings = config[guild_id]["bear"]["ping_settings"]
     return BearPingSettings(
         incoming_enabled=settings.get("incoming_enabled", True),
         pre_attack_enabled=settings.get("pre_attack_enabled", True),
-        pre_attack_offset=settings.get("pre_attack_offset", 10)
+        pre_attack_offset=settings.get("pre_attack_offset", 10),
     )
+
 
 def update_bear_ping_setting(guild_id: str, key: str, value: Any) -> None:
     """Update a bear notification setting"""
     config = _load_config()
     _ensure_notification_settings(config, guild_id, NotificationType.BEAR)
-    
+
     settings = config[guild_id]["bear"]["ping_settings"]
-    
+
     if key == "pre_attack_offset":
         _validate_offset(value)
     elif key not in ["incoming_enabled", "pre_attack_enabled"]:
         raise ConfigValidationError(f"Invalid setting key: {key}")
-    
+
     settings[key] = value
-    
+
     # Validate chronological order after update
     _validate_chronological_order(settings, NotificationType.BEAR)
-    
+
     _save_config(config)
     logger.info(f"Updated bear ping setting for guild {guild_id}: {key}={value}")
+
 
 # Arena notification helpers
 def get_arena_ping_settings(guild_id: str) -> ArenaPingSettings:
     """Get arena notification settings for a guild"""
     config = _load_config()
     _ensure_notification_settings(config, guild_id, NotificationType.ARENA)
-    
+
     settings = config[guild_id]["arena"]["ping_settings"]
     return ArenaPingSettings(
         ping_enabled=settings.get("ping_enabled", True),
-        ping_offset=settings.get("ping_offset", 10)
+        ping_offset=settings.get("ping_offset", 10),
     )
+
 
 def update_arena_ping_setting(guild_id: str, key: str, value: Any) -> None:
     """Update an arena notification setting"""
     config = _load_config()
     _ensure_notification_settings(config, guild_id, NotificationType.ARENA)
-    
+
     settings = config[guild_id]["arena"]["ping_settings"]
-    
+
     if key == "ping_offset":
         _validate_offset(value)
     elif key != "ping_enabled":
         raise ConfigValidationError(f"Invalid setting key: {key}")
-    
+
     settings[key] = value
     _save_config(config)
     logger.info(f"Updated arena ping setting for guild {guild_id}: {key}={value}")
+
 
 # Event notification helpers
 def get_event_ping_settings(guild_id: str) -> EventPingSettings:
     """Get event notification settings for a guild"""
     config = _load_config()
     _ensure_notification_settings(config, guild_id, NotificationType.EVENT)
-    
+
     settings = config[guild_id]["event"]["ping_settings"]
     return EventPingSettings(
         reminder_enabled=settings.get("reminder_enabled", True),
         reminder_offset=settings.get("reminder_offset", 60),
         final_call_enabled=settings.get("final_call_enabled", True),
-        final_call_offset=settings.get("final_call_offset", 10)
+        final_call_offset=settings.get("final_call_offset", 10),
     )
+
 
 def update_event_ping_setting(guild_id: str, key: str, value: Any) -> None:
     """Update an event notification setting"""
     config = _load_config()
     _ensure_notification_settings(config, guild_id, NotificationType.EVENT)
-    
+
     settings = config[guild_id]["event"]["ping_settings"]
-    
+
     if key in ["reminder_offset", "final_call_offset"]:
         _validate_offset(value)
     elif key not in ["reminder_enabled", "final_call_enabled"]:
         raise ConfigValidationError(f"Invalid setting key: {key}")
-    
+
     settings[key] = value
-    
+
     # Validate chronological order after update
     _validate_chronological_order(settings, NotificationType.EVENT)
-    
+
     _save_config(config)
     logger.info(f"Updated event ping setting for guild {guild_id}: {key}={value}")
+
 
 def get_all_ping_settings(guild_id: str) -> Dict[str, Any]:
     """Get all notification settings for a guild"""
     return {
         "bear": get_bear_ping_settings(guild_id).__dict__,
         "arena": get_arena_ping_settings(guild_id).__dict__,
-        "event": get_event_ping_settings(guild_id).__dict__
-    } 
+        "event": get_event_ping_settings(guild_id).__dict__,
+    }


### PR DESCRIPTION
## Summary
- delegate config file writes to `helpers.save_config`
- drop direct file writes and adjust imports

## Testing
- `black --check config_helpers.py helpers.py`
- `flake8 config_helpers.py helpers.py` *(fails: command not found)*
- `python -m py_compile config_helpers.py helpers.py`

------
https://chatgpt.com/codex/tasks/task_e_684b80151530832d979d11b87f06476c